### PR TITLE
Feat/radio button group component

### DIFF
--- a/packages/angular/src/components/radioButton/radio-button.component.ts
+++ b/packages/angular/src/components/radioButton/radio-button.component.ts
@@ -19,5 +19,5 @@ export class RadioButtonComponent {
     readOnly = input(false);
     labelSize = labelSize;
 
-    isInteractive = computed(() => !(this.disabled() && this.readOnly()));
+    isInteractive = computed(() => !(this.disabled() && this.error()));
 }

--- a/packages/angular/src/components/radioButtonGroup/radio-button-group.component.html
+++ b/packages/angular/src/components/radioButtonGroup/radio-button-group.component.html
@@ -1,0 +1,45 @@
+<div  
+    *ngIf="isInteractive()"
+    class="radio-button-group-container">
+    <div
+        class="radio-button-group-header"
+        [ngClass]="{
+            'disabled': disabled(),
+            'error': error(),
+            'read-only': readOnly(),
+        }">
+        <h3
+            *ngIf="showGroupTitle()"
+            class="group-title"
+            >
+            {{ groupTitle() }}
+        </h3>
+        <p
+            *ngIf="showHelpText()"
+            class="group-help-text"
+            >
+            {{ groupHelpText() }}
+
+        </p>
+        <p
+            *ngIf="error()"
+            class="group-error-message"
+            >
+            {{ errorMessage() }}
+        </p>
+    </div>
+    <div class="radio-button-group" 
+        [ngClass]="{'horizontal': direction() === 'horizontal', 'vertical': direction() === 'vertical'}">
+        <ng-container 
+        *ngFor="let item of items()">
+            <rte-radio-button
+                [label]="item"
+                [groupName]="groupName()"
+                [showLabel]="showItemsLabel()"
+                [disabled]="disabled()"
+                [error]="error()"
+                [readOnly]="readOnly()"
+            />
+        </ng-container>
+    </div>
+</div>

--- a/packages/angular/src/components/radioButtonGroup/radio-button-group.component.scss
+++ b/packages/angular/src/components/radioButtonGroup/radio-button-group.component.scss
@@ -1,0 +1,82 @@
+@use '@design-system-rte/core/tokens/main.scss' as *;
+
+.radio-button-group-container {
+    display: flex;
+    padding: $positive-spacing_0;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    gap: $positive-spacing_100;
+
+    .radio-button-group-header {
+
+        .group-title {
+            @include typography-heading-s;
+            align-self: stretch;
+            margin: $positive-spacing_0;
+
+        }
+
+        .group-help-text {
+            @include typography-text-m;
+            color: var(--content-tertiary);
+            align-self: stretch;
+            margin: $positive-spacing_0;
+        }
+
+        .group-error-message {
+            @include typography-text-m-bold;
+            color: var(--content-danger);
+            align-self: stretch;
+            margin: $positive-spacing_0;
+            margin-top: $positive-spacing_050;
+        }
+        
+        &.error {
+            .group-title {
+                color: var(--content-danger);
+            }
+        }
+
+        &.read-only {
+            .group-title {
+                color: var(--content-tertiary);
+            }
+
+            .error{
+                .group-title {
+                    color: var(--content-danger);
+                }
+            }
+        }
+
+        &.disabled {
+
+            pointer-events: none;
+
+            .group-title {
+                color: var(--content-disabled);
+            }
+
+            .group-help-text {
+                color: var(--content-disabled);
+            }
+        }
+
+
+    }
+
+
+    .radio-button-group {
+        display: flex;
+        flex-direction: row;
+        padding: $positive-spacing_0;
+        align-items: flex-start;
+        gap: $positive-spacing_300;
+
+        &.vertical {
+            flex-direction: column;
+            gap: $positive-spacing_100;
+        }
+    }
+}

--- a/packages/angular/src/components/radioButtonGroup/radio-button-group.component.stories.ts
+++ b/packages/angular/src/components/radioButtonGroup/radio-button-group.component.stories.ts
@@ -80,6 +80,12 @@ export const Default: Story = {
     disabled: false,
     readOnly: false,
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const radioButton = canvas.getByLabelText("Option 1");
+    await userEvent.click(radioButton);
+    expect(radioButton).toBeChecked();
+  },
 };
 
 export const Disabled: Story = {

--- a/packages/angular/src/components/radioButtonGroup/radio-button-group.component.stories.ts
+++ b/packages/angular/src/components/radioButtonGroup/radio-button-group.component.stories.ts
@@ -1,0 +1,118 @@
+import { Meta, StoryObj } from "@storybook/angular";
+import { userEvent, within, expect } from "@storybook/test";
+import { RadioButtonGroupComponent } from "./radio-button-group.component";
+
+const meta: Meta<RadioButtonGroupComponent> = {
+  title: "Components/RadioButtonGroup",
+  component: RadioButtonGroupComponent,
+  tags: ["autodocs"],
+  argTypes: {
+    groupName: {
+      control: "text",
+      defaultValue: "group1",
+    },
+    items: {
+      control: "object",
+      defaultValue: ["Option 1", "Option 2", "Option 3"],
+    },
+    direction: {
+      control: "select",
+      options: ["horizontal", "vertical"],
+      defaultValue: "horizontal",
+    },
+    showItemsLabel: {
+      control: "boolean",
+      defaultValue: true,
+    },
+    groupTitle: {
+      control: "text",
+      defaultValue: "Radio Button Group Title",
+    },
+    showGroupTitle: {
+      control: "boolean",
+      defaultValue: true,
+    },
+    groupHelpText: {
+      control: "text",
+      defaultValue:
+        "This is a help text for the radio button group.",
+    },
+    showHelpText: {
+      control: "boolean",
+      defaultValue: true,
+    },
+    errorMessage: {
+      control: "text",
+      defaultValue:
+        'This is an error message. Please select an option.',
+    },
+    error: {
+      control: "boolean",
+      defaultValue: false,
+    },
+    disabled: {
+      control: "boolean",
+      defaultValue: false,
+    },
+    readOnly: {
+      control: "boolean",
+      defaultValue: false,
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<RadioButtonGroupComponent>;
+
+export const Default: Story = {
+  args: {
+    groupName: "group1",
+    items: ["Option 1", "Option 2", "Option 3"],
+    direction: "horizontal",
+    showItemsLabel: true,
+    groupTitle: "Radio Button Group Title",
+    showGroupTitle: true,
+    groupHelpText:
+      "This is a help text for the radio button group.",
+    showHelpText: true,
+    errorMessage:
+      'This is an error message. Please select an option.',
+    error: false,
+    disabled: false,
+    readOnly: false,
+  },
+};
+
+export const Disabled: Story = {
+    args: {
+        ...Default.args,
+        disabled: true,
+    },
+}
+
+export const Error: Story = {
+    args: {
+        ...Default.args,
+        error: true,
+    },
+};
+
+export const ReadOnly: Story = {
+    args: {
+        ...Default.args,
+        readOnly: true,
+    },
+};
+
+export const Vertical: Story = {
+    args: {
+        ...Default.args,
+        direction: "vertical",
+    },
+};
+
+export const Horizontal: Story = {
+    args: {
+        ...Default.args,
+        direction: "horizontal",
+    },
+};

--- a/packages/angular/src/components/radioButtonGroup/radio-button-group.component.ts
+++ b/packages/angular/src/components/radioButtonGroup/radio-button-group.component.ts
@@ -1,0 +1,30 @@
+import { Component, computed, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { RadioButtonComponent } from "../radioButton/radio-button.component";
+
+@Component({
+  selector: 'rte-radio-button-group',
+  standalone: true,
+  imports: [CommonModule, RadioButtonComponent],
+  templateUrl: './radio-button-group.component.html',
+  styleUrls: ['./radio-button-group.component.scss'],
+})
+
+export class RadioButtonGroupComponent {
+    groupName = input('');
+    items = input<string[]>([]);
+    direction = input('horizontal');
+    showItemsLabel = input(true);
+    groupTitle = input('');
+    showGroupTitle = input(false);
+    groupHelpText = input('');
+    showHelpText = input(false);
+    errorMessage = input('');
+    error = input(false);
+    disabled = input(false);
+    readOnly = input(false);
+
+    isInteractive = computed(() => !(this.disabled()==true && this.error()==true));
+
+}
+

--- a/packages/core/components/radio-button-group/radio-button-group.interface.d.ts
+++ b/packages/core/components/radio-button-group/radio-button-group.interface.d.ts
@@ -1,0 +1,16 @@
+export type Direction = "horizontal" | "vertical";
+
+export interface RadioButtonGroupProps {
+    groupName: string;
+    items: string[];
+    direction?: Direction;
+    showItemsLabel?: boolean;
+    groupTitle?: string;
+    showGroupTitle?: boolean;
+    groupHelpText?: string;
+    showHelpText?: boolean;
+    errorMessage?: string;
+    error?: boolean;
+    disabled?: boolean;
+    readOnly?: boolean;
+}

--- a/packages/core/tokens/_typography.scss
+++ b/packages/core/tokens/_typography.scss
@@ -153,6 +153,24 @@ $button-l-semibold-letter-spacing: $letter-spacing-s;
     font-style: normal;
 }
 
+@mixin typography-text-m {
+    @include typography-text;
+    font-family: $text-m-regular-font-family;
+    font-weight: $text-m-regular-font-weight;
+    font-size: $text-m-regular-font-size;
+    line-height: $text-m-regular-line-height;
+    letter-spacing: $text-m-regular-letter-spacing;
+}
+
+@mixin typography-text-m-bold {
+    @include typography-text;
+    font-family: $text-m-bold-font-family;
+    font-weight: $text-m-bold-font-weight;
+    font-size: $text-m-bold-font-size;
+    line-height: $text-m-bold-line-height;
+    letter-spacing: $text-m-bold-letter-spacing;
+}
+
 @mixin typography-text-l {
     @include typography-text;
     font-family: $text-l-regular-font-family;
@@ -188,4 +206,18 @@ $button-l-semibold-letter-spacing: $letter-spacing-s;
     font-weight: $text-l-regular-font-weight;
     line-height: $text-l-regular-line-height;
     letter-spacing: $text-l-regular-letter-spacing;
+}
+
+@mixin typography-heading{
+    font-feature-settings: "liga" off, "clig" off;
+    font-style: normal;
+}
+
+@mixin typography-heading-s{
+    @include typography-heading;
+    font-family: $heading-s-semibold-font-family;
+    font-weight: $heading-s-semibold-font-weight;
+    font-size: $heading-s-semibold-font-size;
+    line-height: $heading-s-semibold-line-height;
+    letter-spacing: $heading-s-semibold-letter-spacing;
 }

--- a/packages/react/src/components/radioButtonGroup/RadioButtonGroup.module.scss
+++ b/packages/react/src/components/radioButtonGroup/RadioButtonGroup.module.scss
@@ -13,6 +13,7 @@
         .groupTitle {
             @include typography-heading-s;
             align-self: stretch;
+            margin: $positive-spacing_0;
 
         }
 
@@ -20,12 +21,46 @@
             @include typography-text-m;
             color: var(--content-tertiary);
             align-self: stretch;
+            margin: $positive-spacing_0;
         }
 
         .errorMessage {
             @include typography-text-m-bold;
             color: var(--content-danger);
             align-self: stretch;
+            margin: $positive-spacing_0;
+            margin-top: $positive-spacing_050;
+        }
+
+        &[data-read-only='true'] {
+            .groupTitle {
+                color: var(--content-tertiary);
+            }
+
+            &[data-error='true'] {
+                .groupTitle {
+                    color: var(--content-danger);
+                }
+            }
+        }
+
+        &[data-disabled='true'] {
+
+            pointer-events: none;
+
+            .groupTitle {
+                color: var(--content-disabled);
+            }
+
+            .groupHelpText {
+                color: var(--content-disabled);
+            }
+        }
+
+        &[data-error='true'] {
+            .groupTitle {
+                color: var(--content-danger);
+            }
         }
 
     }
@@ -37,5 +72,10 @@
         padding: $positive-spacing_0;
         align-items: flex-start;
         gap: $positive-spacing_300;
+
+        &[data-direction='vertical'] {
+            flex-direction: column;
+            gap: $positive-spacing_100;
+        }
     }
 }

--- a/packages/react/src/components/radioButtonGroup/RadioButtonGroup.module.scss
+++ b/packages/react/src/components/radioButtonGroup/RadioButtonGroup.module.scss
@@ -1,0 +1,41 @@
+@use '@design-system-rte/core/tokens/main.scss' as *;
+
+.radioButtonGroupContainer {
+    display: flex;
+    padding: $positive-spacing_0;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    gap: $positive-spacing_100;
+
+    .radioButtonGroupHeader {
+
+        .groupTitle {
+            @include typography-heading-s;
+            align-self: stretch;
+
+        }
+
+        .groupHelpText {
+            @include typography-text-m;
+            color: var(--content-tertiary);
+            align-self: stretch;
+        }
+
+        .errorMessage {
+            @include typography-text-m-bold;
+            color: var(--content-danger);
+            align-self: stretch;
+        }
+
+    }
+
+
+    .radioButtonGroup {
+        display: flex;
+        flex-direction: row;
+        padding: $positive-spacing_0;
+        align-items: flex-start;
+        gap: $positive-spacing_300;
+    }
+}

--- a/packages/react/src/components/radioButtonGroup/RadioButtonGroup.stories.tsx
+++ b/packages/react/src/components/radioButtonGroup/RadioButtonGroup.stories.tsx
@@ -102,3 +102,59 @@ export const Default: Story = {
         expect(radioButton).toBeChecked();
     },
 };
+
+export const Disabled: Story = {
+    args: {
+        ...Default.args,
+        disabled: true,
+    },
+    render: (args) => {
+        return (
+            <div style={{ display: "flex", gap: 8 }}>
+                <RadioButtonGroup {...args} />
+            </div>
+        );
+    },
+};
+
+export const Error: Story = {
+    args: {
+        ...Default.args,
+        error: true,
+    },
+    render: (args) => {
+        return (
+            <div style={{ display: "flex", gap: 8 }}>
+                <RadioButtonGroup {...args} />
+            </div>
+        );
+    },
+};
+
+export const ReadOnly: Story = {
+    args: {
+        ...Default.args,
+        readOnly: true,
+    },
+    render: (args) => {
+        return (
+            <div style={{ display: "flex", gap: 8 }}>
+                <RadioButtonGroup {...args} />
+            </div>
+        );
+    },
+};
+
+export const Directions: Story = {
+    args: {
+        ...Default.args,
+    },
+    render: (args) => {
+        return (
+            <div style={{ display: "flex", gap: 8 }}>
+                <RadioButtonGroup {...args} direction="horizontal" groupName="horizontal" />
+                <RadioButtonGroup {...args} direction="vertical" groupName="vertical" />
+            </div>
+        );
+    },
+};

--- a/packages/react/src/components/radioButtonGroup/RadioButtonGroup.stories.tsx
+++ b/packages/react/src/components/radioButtonGroup/RadioButtonGroup.stories.tsx
@@ -1,0 +1,104 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { userEvent, within, expect } from "@storybook/test";
+import RadioButtonGroup from "./RadioButtonGroup";
+
+const meta = {
+    title: "Components/RadioButtonGroup",
+    component: RadioButtonGroup,
+    tags: ["autodocs"],
+    argTypes: {
+        groupName: {
+            control: "text",
+            description: "The name of the radio button group.",
+            defaultValue: "group1",
+        },
+        items: {
+            control: "object",
+            description: "The items in the radio button group.",
+            defaultValue: ["Option 1", "Option 2", "Option 3"],
+        },
+        direction: {
+            control: "select",
+            options: ["horizontal", "vertical"],
+            description: "The direction of the radio button group.",
+            defaultValue: "horizontal",
+        },
+        showItemsLabel: {
+            control: "boolean",
+            description: "Whether to show the label for each item.",
+            defaultValue: true,
+        },
+        groupTitle: {
+            control: "text",
+            description: "The title of the radio button group.",
+            defaultValue: "Radio Button Group Title",
+        },
+        showGroupTitle: {
+            control: "boolean",
+            description: "Whether to show the group title.",
+            defaultValue: true,
+        },
+        groupHelpText: {
+            control: "text",
+            description: "The help text for the radio button group.",
+            defaultValue: "This is a help text for the radio button group.",
+        },
+        showHelpText: {
+            control: "boolean",
+            description: "Whether to show the help text.",
+            defaultValue: true,
+        },
+        errorMessage: {
+            control: "text",
+            description:
+                'The error message to display when there is an error. Use `error` prop to trigger this message.',
+            defaultValue:
+                'This is an error message. Please select an option.',
+        },
+        error: {
+            control: "boolean",
+            description:
+                'Whether to show the error message. Use `errorMessage` prop to set the message.',
+            defaultValue: false,
+        },
+        disabled: {
+            control: "boolean",
+            description:
+                'Whether the radio button group is disabled. This will disable all radio buttons in the group.',
+            defaultValue: false,
+        },
+        readOnly: {
+            control: "boolean",
+            description:
+                'Whether the radio button group is read-only. This will make all radio buttons in the group read-only.',
+            defaultValue: false,
+        },
+    },
+} satisfies Meta<typeof RadioButtonGroup>;
+
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        groupName: "group1",
+        items: ["Option 1", "Option 2", "Option 3"],
+        direction: "horizontal",
+        showItemsLabel: true,
+        groupTitle: "Radio Button Group Title",
+        showGroupTitle: true,
+        groupHelpText: "This is a help text for the radio button group.",
+        showHelpText: true,
+        errorMessage: "This is an error message. Please select an option.",
+        error: false,
+        disabled: false,
+        readOnly: false,
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const radioButton = canvas.getByRole("radio", { name: "Option 1" });
+        await userEvent.click(radioButton);
+        expect(radioButton).toBeChecked();
+    },
+};

--- a/packages/react/src/components/radioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/react/src/components/radioButtonGroup/RadioButtonGroup.tsx
@@ -1,0 +1,69 @@
+import React, { forwardRef } from "react";
+import { RadioButtonGroupProps as CoreRadioButtonGroupProps } from "@design-system-rte/core/components/radio-button-group/radio-button-group.interface";
+import { concatClassNames } from "../utils";
+import RadioButton from "../radioButton/RadioButton";
+import style from "./RadioButtonGroup.module.scss";
+
+interface RadioButtonGroupProps
+    extends CoreRadioButtonGroupProps,
+    React.AnchorHTMLAttributes<HTMLDivElement> { }
+
+const RadioButtonGroup = forwardRef<HTMLDivElement, RadioButtonGroupProps>(({
+    groupName,
+    items,
+    direction = "horizontal",
+    showItemsLabel = true,
+    groupTitle = '',
+    showGroupTitle = false,
+    groupHelpText = '',
+    showHelpText = false,
+    errorMessage = '',
+    error = false,
+    disabled = false,
+    readOnly = false,
+    className = "",
+    ...props
+}, ref) => {
+
+    if (disabled && error) {
+        return null;
+    }
+
+    return (
+        <div
+            ref={ref}
+            className={concatClassNames(style.radioButtonGroupContainer, className)}
+            data-error={error}
+            data-disabled={disabled}
+            data-read-only={readOnly}
+            {...props}
+        >
+            <div className={style.radioButtonGroupHeader}>
+                {groupTitle && showGroupTitle && (
+                    <h3 className={style.groupTitle}>{groupTitle}</h3>
+                )}
+                {groupHelpText && showHelpText && (
+                    <p className={style.groupHelpText}>{groupHelpText}</p>
+                )}
+                {errorMessage && error && (
+                    <p className={style.errorMessage}>{errorMessage}</p>
+                )}
+            </div>
+            <div className={style.radioButtonGroup}>
+                {items.map((item, index) => (
+                    <RadioButton
+                        key={index}
+                        label={item}
+                        groupName={groupName}
+                        showLabel={showItemsLabel}
+                        disabled={disabled}
+                        error={error}
+                        readOnly={readOnly}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+})
+
+export default RadioButtonGroup;

--- a/packages/react/src/components/radioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/react/src/components/radioButtonGroup/RadioButtonGroup.tsx
@@ -26,19 +26,19 @@ const RadioButtonGroup = forwardRef<HTMLDivElement, RadioButtonGroupProps>(({
 }, ref) => {
 
     if (disabled && error) {
-        return null;
+        return;
     }
 
     return (
         <div
             ref={ref}
             className={concatClassNames(style.radioButtonGroupContainer, className)}
-            data-error={error}
-            data-disabled={disabled}
-            data-read-only={readOnly}
             {...props}
         >
-            <div className={style.radioButtonGroupHeader}>
+            <div className={style.radioButtonGroupHeader}
+            data-error={error}
+            data-disabled={disabled}
+            data-read-only={readOnly}>
                 {groupTitle && showGroupTitle && (
                     <h3 className={style.groupTitle}>{groupTitle}</h3>
                 )}
@@ -49,7 +49,8 @@ const RadioButtonGroup = forwardRef<HTMLDivElement, RadioButtonGroupProps>(({
                     <p className={style.errorMessage}>{errorMessage}</p>
                 )}
             </div>
-            <div className={style.radioButtonGroup}>
+            <div className={style.radioButtonGroup}
+                data-direction={direction}>
                 {items.map((item, index) => (
                     <RadioButton
                         key={index}


### PR DESCRIPTION
This pull request introduces a new `RadioButtonGroup` component for both Angular and React, along with associated styles, functionality, and Storybook stories. It also includes updates to the typography mixins in the design system tokens. The most important changes are grouped below by theme.

### Angular `RadioButtonGroup` Component:

* **Component Implementation**: Added the `RadioButtonGroupComponent` class with inputs for group configuration (e.g., `items`, `direction`, `error`, `disabled`) and a computed property `isInteractive` to determine interactivity. (`packages/angular/src/components/radioButtonGroup/radio-button-group.component.ts`, [packages/angular/src/components/radioButtonGroup/radio-button-group.component.tsR1-R30](diffhunk://#diff-85f6e6e2fa0dc8131e06d5bb5cd3f526a0e31e67ad51425ebc4ed5ca3676823cR1-R30))
* **Template**: Created an HTML template for the `RadioButtonGroup` component, supporting dynamic rendering of group title, help text, error messages, and radio buttons based on inputs. (`packages/angular/src/components/radioButtonGroup/radio-button-group.component.html`, [packages/angular/src/components/radioButtonGroup/radio-button-group.component.htmlR1-R45](diffhunk://#diff-571df5fca00e3053b6ac0c75b3b792750890f76520952684751f154e8224df76R1-R45))
* **Styles**: Added SCSS styles for the `RadioButtonGroup` component, including support for error, disabled, and read-only states, as well as horizontal and vertical layouts. (`packages/angular/src/components/radioButtonGroup/radio-button-group.component.scss`, [packages/angular/src/components/radioButtonGroup/radio-button-group.component.scssR1-R82](diffhunk://#diff-293f6e34da46e2f42ce67e6850cb4bd6625a18b13c90890de849994de3bdc292R1-R82))
* **Storybook Stories**: Added Storybook stories for the `RadioButtonGroupComponent`, showcasing different states (default, disabled, error, read-only, horizontal, vertical). (`packages/angular/src/components/radioButtonGroup/radio-button-group.component.stories.ts`, [packages/angular/src/components/radioButtonGroup/radio-button-group.component.stories.tsR1-R124](diffhunk://#diff-915ce776477a7ddc46fa2ef62ba42a8245f22013832d4628f7066d9987fee745R1-R124))

### React `RadioButtonGroup` Component:

* **Component Implementation**: Added the `RadioButtonGroup` React component with props for configuration (e.g., `items`, `direction`, `error`, `disabled`) and conditional rendering for group elements. (`packages/react/src/components/radioButtonGroup/RadioButtonGroup.tsx`, [packages/react/src/components/radioButtonGroup/RadioButtonGroup.tsxR1-R70](diffhunk://#diff-7f87a68c879d9a1c9b68e89fb28e467d54ea84b975de6b8590d5106f5511d9e5R1-R70))
* **Styles**: Added SCSS styles for the React `RadioButtonGroup` component, similar to the Angular implementation, with support for various states and layouts. (`packages/react/src/components/radioButtonGroup/RadioButtonGroup.module.scss`, [packages/react/src/components/radioButtonGroup/RadioButtonGroup.module.scssR1-R81](diffhunk://#diff-b3ee8bfd08e6cf7ffad6da3707d9536c40211c4ace2e112daf3b87df447fd613R1-R81))
* **Storybook Stories**: Added Storybook stories for the `RadioButtonGroup` React component, demonstrating different configurations and states. (`packages/react/src/components/radioButtonGroup/RadioButtonGroup.stories.tsx`, [packages/react/src/components/radioButtonGroup/RadioButtonGroup.stories.tsxR1-R160](diffhunk://#diff-178a9c75d7ed7ad4ddccb6eca66c1a42040d0763a7096e096637d58fe094c8adR1-R160))

### Shared Design Updates:

* **Typography Mixins**: Added new typography mixins (`typography-text-m`, `typography-text-m-bold`, `typography-heading-s`) to the design system tokens for consistent styling across components. (`packages/core/tokens/_typography.scss`, [[1]](diffhunk://#diff-ec35aca4bb13bf9c041eeadf79a6d01fe475374ce32814efc88b4da090141aeaR156-R173) [[2]](diffhunk://#diff-ec35aca4bb13bf9c041eeadf79a6d01fe475374ce32814efc88b4da090141aeaR210-R223)

### Minor Adjustment:

* **Bug Fix in `RadioButtonComponent`**: Updated the `isInteractive` computed property to use `error()` instead of `readOnly()` for determining interactivity. (`packages/angular/src/components/radioButton/radio-button.component.ts`, [packages/angular/src/components/radioButton/radio-button.component.tsL22-R22](diffhunk://#diff-37cff7e8f42bcb94d25499f43b0a42fea5542c2b725cd30c7a31043d3e4570ddL22-R22))

(quel bro ce Copilot)